### PR TITLE
Derive Debug for `Type` and `Object`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "piston-editor"
-version = "0.2.0"
+version = "0.2.1"
 authors = [
     "bvssvni <bvssvni@gmail.com>"
 ]
@@ -12,4 +12,4 @@ homepage = "https://github.com/PistonDevelopers/editor"
 
 [lib]
 name = "editor"
-src = "./src/lib.rs"
+path = "./src/lib.rs"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,10 +105,10 @@ pub trait Editor {
 /// The type of an object.
 /// This does not have be unique for Rust types.
 /// Dynamically typed objects should use same id.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Type(pub &'static str);
 /// The object id.
-#[derive(Clone, Copy)]
+#[derive(Clone, Copy, Debug)]
 pub struct Object(pub usize);
 
 /// Stores information about a reference.


### PR DESCRIPTION
- Changed “src” to “path” in Cargo.toml
